### PR TITLE
Add basic Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: build
+build:
+	docker build \
+	-t bakerba/implant .
+
+lint:
+	grep -rIl '^#![[:blank:]]*/bin/\(bash\|sh\|zsh\)' \
+	--exclude-dir=.git --exclude=*.sw? \
+	| xargs shellcheck -x
+	# List files which name starts with 'Dockerfile'
+	# eg. Dockerfile, Dockerfile.build, etc.
+	git ls-files --exclude='Dockerfile*' --ignored | xargs --max-lines=1 hadolint


### PR DESCRIPTION
Hi, I think your project is quite interesting. I want to see if I can update your Dockerfile to using buster and to quickly build the Dockerfile I thought I'll add a Makefile first.

Shellcheck also reports quite some things for the bundled scripts.